### PR TITLE
Fix: Correctly pass str values as query parameters

### DIFF
--- a/phrasetms_client/api/analysis_api.py
+++ b/phrasetms_client/api/analysis_api.py
@@ -1062,7 +1062,7 @@ class AnalysisApi(object):
         # process the query parameters
         _query_params = []
         if _params.get('format') is not None:  # noqa: E501
-            _query_params.append(('format', _params['format'].value))
+            _query_params.append(('format', _params['format']))
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
@@ -1865,10 +1865,10 @@ class AnalysisApi(object):
             _query_params.append(('pageSize', _params['page_size']))
 
         if _params.get('sort') is not None:  # noqa: E501
-            _query_params.append(('sort', _params['sort'].value))
+            _query_params.append(('sort', _params['sort']))
 
         if _params.get('order') is not None:  # noqa: E501
-            _query_params.append(('order', _params['order'].value))
+            _query_params.append(('order', _params['order']))
 
         if _params.get('only_owner_org') is not None:  # noqa: E501
             _query_params.append(('onlyOwnerOrg', _params['only_owner_org']))

--- a/phrasetms_client/api/bilingual_file_api.py
+++ b/phrasetms_client/api/bilingual_file_api.py
@@ -323,10 +323,10 @@ class BilingualFileApi(object):
         # process the query parameters
         _query_params = []
         if _params.get('var_from') is not None:  # noqa: E501
-            _query_params.append(('from', _params['var_from'].value))
+            _query_params.append(('from', _params['var_from']))
 
         if _params.get('to') is not None:  # noqa: E501
-            _query_params.append(('to', _params['to'].value))
+            _query_params.append(('to', _params['to']
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
@@ -487,7 +487,7 @@ class BilingualFileApi(object):
         # process the query parameters
         _query_params = []
         if _params.get('format') is not None:  # noqa: E501
-            _query_params.append(('format', _params['format'].value))
+            _query_params.append(('format', _params['format']
 
         if _params.get('preview') is not None:  # noqa: E501
             _query_params.append(('preview', _params['preview']))
@@ -783,7 +783,7 @@ class BilingualFileApi(object):
         # process the query parameters
         _query_params = []
         if _params.get('save_to_trans_memory') is not None:  # noqa: E501
-            _query_params.append(('saveToTransMemory', _params['save_to_trans_memory'].value))
+            _query_params.append(('saveToTransMemory', _params['save_to_trans_memory']
 
         if _params.get('set_completed') is not None:  # noqa: E501
             _query_params.append(('setCompleted', _params['set_completed']))

--- a/phrasetms_client/api/bilingual_file_api.py
+++ b/phrasetms_client/api/bilingual_file_api.py
@@ -326,7 +326,7 @@ class BilingualFileApi(object):
             _query_params.append(('from', _params['var_from']))
 
         if _params.get('to') is not None:  # noqa: E501
-            _query_params.append(('to', _params['to']
+            _query_params.append(('to', _params['to']))
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
@@ -487,7 +487,7 @@ class BilingualFileApi(object):
         # process the query parameters
         _query_params = []
         if _params.get('format') is not None:  # noqa: E501
-            _query_params.append(('format', _params['format']
+            _query_params.append(('format', _params['format']))
 
         if _params.get('preview') is not None:  # noqa: E501
             _query_params.append(('preview', _params['preview']))
@@ -783,7 +783,7 @@ class BilingualFileApi(object):
         # process the query parameters
         _query_params = []
         if _params.get('save_to_trans_memory') is not None:  # noqa: E501
-            _query_params.append(('saveToTransMemory', _params['save_to_trans_memory']
+            _query_params.append(('saveToTransMemory', _params['save_to_trans_memory']))
 
         if _params.get('set_completed') is not None:  # noqa: E501
             _query_params.append(('setCompleted', _params['set_completed']))

--- a/phrasetms_client/api/business_unit_api.py
+++ b/phrasetms_client/api/business_unit_api.py
@@ -612,10 +612,10 @@ class BusinessUnitApi(object):
             _query_params.append(('createdBy', _params['created_by']))
 
         if _params.get('sort') is not None:  # noqa: E501
-            _query_params.append(('sort', _params['sort'].value))
+            _query_params.append(('sort', _params['sort']))
 
         if _params.get('order') is not None:  # noqa: E501
-            _query_params.append(('order', _params['order'].value))
+            _query_params.append(('order', _params['order']))
 
         if _params.get('page_number') is not None:  # noqa: E501
             _query_params.append(('pageNumber', _params['page_number']))

--- a/phrasetms_client/api/client_api.py
+++ b/phrasetms_client/api/client_api.py
@@ -615,7 +615,7 @@ class ClientApi(object):
             _query_params.append(('sort', _params['sort']))
 
         if _params.get('order') is not None:  # noqa: E501
-            _query_params.append(('order', _params['order']
+            _query_params.append(('order', _params['order']))
 
         if _params.get('page_number') is not None:  # noqa: E501
             _query_params.append(('pageNumber', _params['page_number']))

--- a/phrasetms_client/api/client_api.py
+++ b/phrasetms_client/api/client_api.py
@@ -612,10 +612,10 @@ class ClientApi(object):
             _query_params.append(('createdBy', _params['created_by']))
 
         if _params.get('sort') is not None:  # noqa: E501
-            _query_params.append(('sort', _params['sort'].value))
+            _query_params.append(('sort', _params['sort']))
 
         if _params.get('order') is not None:  # noqa: E501
-            _query_params.append(('order', _params['order'].value))
+            _query_params.append(('order', _params['order']
 
         if _params.get('page_number') is not None:  # noqa: E501
             _query_params.append(('pageNumber', _params['page_number']))

--- a/phrasetms_client/api/cost_center_api.py
+++ b/phrasetms_client/api/cost_center_api.py
@@ -612,10 +612,10 @@ class CostCenterApi(object):
             _query_params.append(('createdBy', _params['created_by']))
 
         if _params.get('sort') is not None:  # noqa: E501
-            _query_params.append(('sort', _params['sort'].value))
+            _query_params.append(('sort', _params['sort']))
 
         if _params.get('order') is not None:  # noqa: E501
-            _query_params.append(('order', _params['order'].value))
+            _query_params.append(('order', _params['order']))
 
         if _params.get('page_number') is not None:  # noqa: E501
             _query_params.append(('pageNumber', _params['page_number']))

--- a/phrasetms_client/api/custom_fields_api.py
+++ b/phrasetms_client/api/custom_fields_api.py
@@ -533,10 +533,10 @@ class CustomFieldsApi(object):
             _query_params.append(('required', _params['required']))
 
         if _params.get('sort_field') is not None:  # noqa: E501
-            _query_params.append(('sortField', _params['sort_field'].value))
+            _query_params.append(('sortField', _params['sort_field']))
 
         if _params.get('sort_trend') is not None:  # noqa: E501
-            _query_params.append(('sortTrend', _params['sort_trend'].value))
+            _query_params.append(('sortTrend', _params['sort_trend']))
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
@@ -721,10 +721,10 @@ class CustomFieldsApi(object):
             _query_params.append(('name', _params['name']))
 
         if _params.get('sort_field') is not None:  # noqa: E501
-            _query_params.append(('sortField', _params['sort_field'].value))
+            _query_params.append(('sortField', _params['sort_field']))
 
         if _params.get('sort_trend') is not None:  # noqa: E501
-            _query_params.append(('sortTrend', _params['sort_trend'].value))
+            _query_params.append(('sortTrend', _params['sort_trend']))
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))

--- a/phrasetms_client/api/domain_api.py
+++ b/phrasetms_client/api/domain_api.py
@@ -612,10 +612,10 @@ class DomainApi(object):
             _query_params.append(('createdBy', _params['created_by']))
 
         if _params.get('sort') is not None:  # noqa: E501
-            _query_params.append(('sort', _params['sort'].value))
+            _query_params.append(('sort', _params['sort']))
 
         if _params.get('order') is not None:  # noqa: E501
-            _query_params.append(('order', _params['order'].value))
+            _query_params.append(('order', _params['order']))
 
         if _params.get('page_number') is not None:  # noqa: E501
             _query_params.append(('pageNumber', _params['page_number']))

--- a/phrasetms_client/api/job_api.py
+++ b/phrasetms_client/api/job_api.py
@@ -1946,7 +1946,7 @@ class JobApi(object):
         # process the query parameters
         _query_params = []
         if _params.get('format') is not None:  # noqa: E501
-            _query_params.append(('format', _params['format'].value))
+            _query_params.append(('format', _params['format']))
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
@@ -3053,7 +3053,7 @@ class JobApi(object):
         # process the query parameters
         _query_params = []
         if _params.get('format') is not None:  # noqa: E501
-            _query_params.append(('format', _params['format'].value))
+            _query_params.append(('format', _params['format']))
 
         if _params.get('preview') is not None:  # noqa: E501
             _query_params.append(('preview', _params['preview']))
@@ -7793,10 +7793,10 @@ class JobApi(object):
         # process the query parameters
         _query_params = []
         if _params.get('format') is not None:  # noqa: E501
-            _query_params.append(('format', _params['format'].value))
+            _query_params.append(('format', _params['format']))
 
         if _params.get('save_to_trans_memory') is not None:  # noqa: E501
-            _query_params.append(('saveToTransMemory', _params['save_to_trans_memory'].value))
+            _query_params.append(('saveToTransMemory', _params['save_to_trans_memory']))
 
         if _params.get('set_completed') is not None:  # noqa: E501
             _query_params.append(('setCompleted', _params['set_completed']))

--- a/phrasetms_client/api/machine_translation_settings_api.py
+++ b/phrasetms_client/api/machine_translation_settings_api.py
@@ -178,7 +178,7 @@ class MachineTranslationSettingsApi(object):
             _query_params.append(('pageSize', _params['page_size']))
 
         if _params.get('sort') is not None:  # noqa: E501
-            _query_params.append(('sort', _params['sort'].value))
+            _query_params.append(('sort', _params['sort']))
 
         if _params.get('order') is not None:  # noqa: E501
             _query_params.append(('order', _params['order']))
@@ -794,7 +794,7 @@ class MachineTranslationSettingsApi(object):
             _query_params.append(('pageSize', _params['page_size']))
 
         if _params.get('sort') is not None:  # noqa: E501
-            _query_params.append(('sort', _params['sort'].value))
+            _query_params.append(('sort', _params['sort']))
 
         if _params.get('order') is not None:  # noqa: E501
             _query_params.append(('order', _params['order']))

--- a/phrasetms_client/api/project_api.py
+++ b/phrasetms_client/api/project_api.py
@@ -3658,10 +3658,10 @@ class ProjectApi(object):
             _collection_formats['modifiedBy'] = 'multi'
 
         if _params.get('sort_field') is not None:  # noqa: E501
-            _query_params.append(('sortField', _params['sort_field'].value))
+            _query_params.append(('sortField', _params['sort_field']))
 
         if _params.get('sort_trend') is not None:  # noqa: E501
-            _query_params.append(('sortTrend', _params['sort_trend'].value))
+            _query_params.append(('sortTrend', _params['sort_trend']))
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
@@ -6069,10 +6069,10 @@ class ProjectApi(object):
             _query_params.append(('pageSize', _params['page_size']))
 
         if _params.get('sort') is not None:  # noqa: E501
-            _query_params.append(('sort', _params['sort'].value))
+            _query_params.append(('sort', _params['sort']))
 
         if _params.get('order') is not None:  # noqa: E501
-            _query_params.append(('order', _params['order'].value))
+            _query_params.append(('order', _params['order']))
 
         if _params.get('only_owner_org') is not None:  # noqa: E501
             _query_params.append(('onlyOwnerOrg', _params['only_owner_org']))
@@ -6401,7 +6401,7 @@ class ProjectApi(object):
             _collection_formats['jobStatuses'] = 'multi'
 
         if _params.get('job_status_group') is not None:  # noqa: E501
-            _query_params.append(('jobStatusGroup', _params['job_status_group'].value))
+            _query_params.append(('jobStatusGroup', _params['job_status_group']))
 
         if _params.get('buyer_id') is not None:  # noqa: E501
             _query_params.append(('buyerId', _params['buyer_id']))

--- a/phrasetms_client/api/project_reference_file_api.py
+++ b/phrasetms_client/api/project_reference_file_api.py
@@ -972,10 +972,10 @@ class ProjectReferenceFileApi(object):
             _query_params.append(('pageSize', _params['page_size']))
 
         if _params.get('sort') is not None:  # noqa: E501
-            _query_params.append(('sort', _params['sort'].value))
+            _query_params.append(('sort', _params['sort']))
 
         if _params.get('order') is not None:  # noqa: E501
-            _query_params.append(('order', _params['order'].value))
+            _query_params.append(('order', _params['order']))
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))

--- a/phrasetms_client/api/project_template_api.py
+++ b/phrasetms_client/api/project_template_api.py
@@ -2719,10 +2719,10 @@ class ProjectTemplateApi(object):
             _collection_formats['modifiedBy'] = 'multi'
 
         if _params.get('sort_field') is not None:  # noqa: E501
-            _query_params.append(('sortField', _params['sort_field'].value))
+            _query_params.append(('sortField', _params['sort_field']))
 
         if _params.get('sort_trend') is not None:  # noqa: E501
-            _query_params.append(('sortTrend', _params['sort_trend'].value))
+            _query_params.append(('sortTrend', _params['sort_trend']))
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))

--- a/phrasetms_client/api/scim_api.py
+++ b/phrasetms_client/api/scim_api.py
@@ -1552,7 +1552,7 @@ class SCIMApi(object):
             _query_params.append(('sortBy', _params['sort_by']))
 
         if _params.get('sort_order') is not None:  # noqa: E501
-            _query_params.append(('sortOrder', _params['sort_order'].value))
+            _query_params.append(('sortOrder', _params['sort_order']))
 
         if _params.get('start_index') is not None:  # noqa: E501
             _query_params.append(('startIndex', _params['start_index']))

--- a/phrasetms_client/api/sub_domain_api.py
+++ b/phrasetms_client/api/sub_domain_api.py
@@ -612,10 +612,10 @@ class SubDomainApi(object):
             _query_params.append(('createdBy', _params['created_by']))
 
         if _params.get('sort') is not None:  # noqa: E501
-            _query_params.append(('sort', _params['sort'].value))
+            _query_params.append(('sort', _params['sort']))
 
         if _params.get('order') is not None:  # noqa: E501
-            _query_params.append(('order', _params['order'].value))
+            _query_params.append(('order', _params['order']))
 
         if _params.get('page_number') is not None:  # noqa: E501
             _query_params.append(('pageNumber', _params['page_number']))

--- a/phrasetms_client/api/term_base_api.py
+++ b/phrasetms_client/api/term_base_api.py
@@ -1706,13 +1706,13 @@ class TermBaseApi(object):
         # process the query parameters
         _query_params = []
         if _params.get('format') is not None:  # noqa: E501
-            _query_params.append(('format', _params['format'].value))
+            _query_params.append(('format', _params['format']))
 
         if _params.get('charset') is not None:  # noqa: E501
             _query_params.append(('charset', _params['charset']))
 
         if _params.get('term_status') is not None:  # noqa: E501
-            _query_params.append(('termStatus', _params['term_status'].value))
+            _query_params.append(('termStatus', _params['term_status']))
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))

--- a/phrasetms_client/api/translation_memory_api.py
+++ b/phrasetms_client/api/translation_memory_api.py
@@ -1326,7 +1326,7 @@ class TranslationMemoryApi(object):
         # process the query parameters
         _query_params = []
         if _params.get('format') is not None:  # noqa: E501
-            _query_params.append(('format', _params['format'].value))
+            _query_params.append(('format', _params['format']))
 
         if _params.get('fields') is not None:  # noqa: E501
             _query_params.append(('fields', _params['fields']))

--- a/phrasetms_client/api/webhook_api.py
+++ b/phrasetms_client/api/webhook_api.py
@@ -638,7 +638,7 @@ class WebhookApi(object):
             _query_params.append(('name', _params['name']))
 
         if _params.get('status') is not None:  # noqa: E501
-            _query_params.append(('status', _params['status'].value))
+            _query_params.append(('status', _params['status']))
 
         if _params.get('url') is not None:  # noqa: E501
             _query_params.append(('url', _params['url']))
@@ -656,10 +656,10 @@ class WebhookApi(object):
             _collection_formats['modifiedBy'] = 'multi'
 
         if _params.get('sort_field') is not None:  # noqa: E501
-            _query_params.append(('sortField', _params['sort_field'].value))
+            _query_params.append(('sortField', _params['sort_field']))
 
         if _params.get('sort_trend') is not None:  # noqa: E501
-            _query_params.append(('sortTrend', _params['sort_trend'].value))
+            _query_params.append(('sortTrend', _params['sort_trend']))
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
@@ -842,7 +842,7 @@ class WebhookApi(object):
             _collection_formats['events'] = 'multi'
 
         if _params.get('status') is not None:  # noqa: E501
-            _query_params.append(('status', _params['status'].value))
+            _query_params.append(('status', _params['status']))
 
         if _params.get('webhook_uid') is not None:  # noqa: E501
             _query_params.append(('webhookUid', _params['webhook_uid']))
@@ -1164,7 +1164,7 @@ class WebhookApi(object):
             _collection_formats['events'] = 'multi'
 
         if _params.get('status') is not None:  # noqa: E501
-            _query_params.append(('status', _params['status'].value))
+            _query_params.append(('status', _params['status']))
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
@@ -1436,7 +1436,7 @@ class WebhookApi(object):
         # process the query parameters
         _query_params = []
         if _params.get('event') is not None:  # noqa: E501
-            _query_params.append(('event', _params['event'].value))
+            _query_params.append(('event', _params['event']))
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))

--- a/phrasetms_client/api/workflow_step_api.py
+++ b/phrasetms_client/api/workflow_step_api.py
@@ -498,10 +498,10 @@ class WorkflowStepApi(object):
             _query_params.append(('pageSize', _params['page_size']))
 
         if _params.get('sort') is not None:  # noqa: E501
-            _query_params.append(('sort', _params['sort'].value))
+            _query_params.append(('sort', _params['sort']))
 
         if _params.get('order') is not None:  # noqa: E501
-            _query_params.append(('order', _params['order'].value))
+            _query_params.append(('order', _params['order']))
 
         if _params.get('name') is not None:  # noqa: E501
             _query_params.append(('name', _params['name']))


### PR DESCRIPTION
The `.value` attribute was being incorrectly accessed when passing str values as query parameters. This change removes the `.value` access and passes the str value directly, which is the expected behavior.