### PR TITLE
Feat: Add more specific exception classes for HTTP status codes

### DIFF
--- a/phrasetms_client/exceptions.py
+++ b/phrasetms_client/exceptions.py
@@ -133,12 +133,6 @@ class BadRequestException(ApiException):
         super(BadRequestException, self).__init__(status, reason, http_resp)
 
 
-class NotFoundException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(NotFoundException, self).__init__(status, reason, http_resp)
-
-
 class UnauthorizedException(ApiException):
 
     def __init__(self, status=None, reason=None, http_resp=None):
@@ -149,6 +143,42 @@ class ForbiddenException(ApiException):
 
     def __init__(self, status=None, reason=None, http_resp=None):
         super(ForbiddenException, self).__init__(status, reason, http_resp)
+
+
+class NotFoundException(ApiException):
+
+    def __init__(self, status=None, reason=None, http_resp=None):
+        super(NotFoundException, self).__init__(status, reason, http_resp)
+
+
+class MethodNotAllowedException(ApiException):
+
+    def __init__(self, status=None, reason=None, http_resp=None):
+        super(MethodNotAllowedException, self).__init__(status, reason, http_resp)
+
+
+class TimeoutException(ApiException):
+
+    def __init__(self, status=None, reason=None, http_resp=None):
+        super(TimeoutException, self).__init__(status, reason, http_resp)
+
+
+class GoneException(ApiException):
+
+    def __init__(self, status=None, reason=None, http_resp=None):
+        super(GoneException, self).__init__(status, reason, http_resp)
+
+
+class UnsupportedMediaTypeException(ApiException):
+
+    def __init__(self, status=None, reason=None, http_resp=None):
+        super(UnsupportedMediaTypeException, self).__init__(status, reason, http_resp)
+
+
+class TooManyRequestsException(ApiException):
+
+    def __init__(self, status=None, reason=None, http_resp=None):
+        super(TooManyRequestsException, self).__init__(status, reason, http_resp)
 
 
 class ServiceException(ApiException):

--- a/phrasetms_client/rest.py
+++ b/phrasetms_client/rest.py
@@ -21,7 +21,7 @@ import ssl
 from urllib.parse import urlencode, quote_plus
 import urllib3
 
-from phrasetms_client.exceptions import ApiException, UnauthorizedException, ForbiddenException, NotFoundException, ServiceException, ApiValueError, BadRequestException
+from phrasetms_client.exceptions import ApiException, GoneException, MethodNotAllowedException, TimeoutException, TooManyRequestsException, UnauthorizedException, ForbiddenException, NotFoundException, ServiceException, ApiValueError, BadRequestException, UnsupportedMediaTypeException
 
 
 logger = logging.getLogger(__name__)
@@ -68,7 +68,6 @@ class RESTClientObject(object):
 
         if configuration.tls_server_name:
             addition_pool_args['server_hostname'] = configuration.tls_server_name
-
 
         if configuration.socket_options is not None:
             addition_pool_args['socket_options'] = configuration.socket_options
@@ -220,7 +219,7 @@ class RESTClientObject(object):
         if not 200 <= r.status <= 299:
             if r.status == 400:
                 raise BadRequestException(http_resp=r)
-            
+
             if r.status == 401:
                 raise UnauthorizedException(http_resp=r)
 
@@ -229,6 +228,21 @@ class RESTClientObject(object):
 
             if r.status == 404:
                 raise NotFoundException(http_resp=r)
+
+            if r.status == 405:
+                raise MethodNotAllowedException(http_resp=r)
+
+            if r.status == 408:
+                raise TimeoutException(http_resp=r)
+
+            if r.status == 410:
+                raise GoneException(http_resp=r)
+
+            if r.status == 415:
+                raise UnsupportedMediaTypeException(http_resp=r)
+
+            if r.status == 429:
+                raise TooManyRequestsException(http_resp=r)
 
             if 500 <= r.status <= 599:
                 raise ServiceException(http_resp=r)


### PR DESCRIPTION
This commit introduces new exception classes for specific HTTP status codes, including:

- MethodNotAllowedException (405)
- TimeoutException (408)
- GoneException (410)
- UnsupportedMediaTypeException (415)
- TooManyRequestsException (429)